### PR TITLE
feat: respect hidepages plugin syntax

### DIFF
--- a/syntax/indexmenu.php
+++ b/syntax/indexmenu.php
@@ -674,6 +674,11 @@ class syntax_plugin_indexmenu_indexmenu extends DokuWiki_Syntax_Plugin {
         $skip_file  = $opts['skip_file'];
         $headpage   = $opts['headpage'];
         $id         = pathID($file);
+        
+        //respect hidepages plugin (https://www.dokuwiki.org/plugin:hidepages) metadata
+        $meta = p_get_metadata($id);
+        if (isset($meta['hidepage'])) return false;
+
         if($type == 'd') {
             // Skip folders in plugin conf
             foreach($skip_index as $skipi) {


### PR DESCRIPTION
This PR adds support for https://www.dokuwiki.org/plugin:hidepages (```~~HIDEPAGE~~```). Everything which has that metadata somewhere will be ignored/hidden in the indexmenu